### PR TITLE
API Bitmap (framebuffer) backed by float32 pixels

### DIFF
--- a/Dependencies/IGraphics/MetalNanoVG/src/nanovg_mtl.m
+++ b/Dependencies/IGraphics/MetalNanoVG/src/nanovg_mtl.m
@@ -1162,8 +1162,11 @@ enum MNVGTarget mnvgTarget(void) {
   MNVGtexture* tex = [self allocTexture];
 
   if (tex == nil) return 0;
-
-  MTLPixelFormat pixelFormat = MTLPixelFormatRGBA8Unorm;
+  bool useFloats = imageFlags & NVG_IMAGE_FLOAT32;
+  int numComponents = (type == NVG_TEXTURE_RGBA) ? 4 : 1;
+  int bytesPerComponent = (useFloats) ? 4 : 1;
+  int bytesPerPixel = bytesPerComponent * numComponents;
+  MTLPixelFormat pixelFormat = (useFloats) ? MTLPixelFormatRGBA32Float : MTLPixelFormatRGBA8Unorm;
   if (type == NVG_TEXTURE_ALPHA) {
     pixelFormat = MTLPixelFormatR8Unorm;
   }
@@ -1187,7 +1190,7 @@ enum MNVGTarget mnvgTarget(void) {
   if (data != NULL) {
     NSUInteger bytesPerRow;
     if (tex->type == NVG_TEXTURE_RGBA) {
-      bytesPerRow = width * 4;
+      bytesPerRow = width * bytesPerPixel;
     } else {
       bytesPerRow = width;
     }

--- a/Dependencies/IGraphics/NanoVG/src/nanovg.h
+++ b/Dependencies/IGraphics/NanoVG/src/nanovg.h
@@ -142,6 +142,7 @@ enum NVGimageFlags {
 	NVG_IMAGE_FLIPY				= 1<<3,		// Flips (inverses) image in Y direction when rendered.
 	NVG_IMAGE_PREMULTIPLIED		= 1<<4,		// Image data has premultiplied alpha.
 	NVG_IMAGE_NEAREST			= 1<<5,		// Image interpolation is Nearest instead Linear
+	NVG_IMAGE_FLOAT32			= 1<<6      // Use 32-bit float as texture data format
 };
 
 // Begin drawing a new frame

--- a/Dependencies/IGraphics/NanoVG/src/nanovg_gl.h
+++ b/Dependencies/IGraphics/NanoVG/src/nanovg_gl.h
@@ -759,9 +759,14 @@ static int glnvg__renderCreateTexture(void* uptr, int type, int w, int h, int im
 	}
 #endif
 
-	if (type == NVG_TEXTURE_RGBA)
-		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, w, h, 0, GL_RGBA, GL_UNSIGNED_BYTE, data);
-	else
+  if (type == NVG_TEXTURE_RGBA) {
+	  int pixelformat = GL_RGBA;
+#if defined (NANOVG_GL3)
+	if (imageFlags & NVG_IMAGE_FLOAT32) { pixelformat = GL_RGBA32F; }
+#endif
+    int compformat  = (imageFlags & NVG_IMAGE_FLOAT32) ? GL_FLOAT   : GL_BYTE;
+    glTexImage2D(GL_TEXTURE_2D, 0, pixelformat, w, h, 0, GL_RGBA, compformat, data);
+  } else
 #if defined(NANOVG_GLES2) || defined (NANOVG_GL2)
 		glTexImage2D(GL_TEXTURE_2D, 0, GL_LUMINANCE, w, h, 0, GL_LUMINANCE, GL_UNSIGNED_BYTE, data);
 #elif defined(NANOVG_GLES3)

--- a/IGraphics/Drawing/IGraphicsNanoVG.cpp
+++ b/IGraphics/Drawing/IGraphicsNanoVG.cpp
@@ -76,7 +76,7 @@ class IGraphicsNanoVG::Bitmap : public APIBitmap
 {
 public:
   Bitmap(NVGcontext* pContext, const char* path, double sourceScale, int nvgImageID, bool shared = false);
-  Bitmap(IGraphicsNanoVG* pGraphics, NVGcontext* pContext, int width, int height, float scale, float drawScale);
+  Bitmap(IGraphicsNanoVG* pGraphics, NVGcontext* pContext, int width, int height, float scale, float drawScale, bool useFloat32 = false);
   Bitmap(NVGcontext* pContext, int width, int height, const uint8_t* pData, float scale, float drawScale);
   virtual ~Bitmap();
   NVGframebuffer* GetFBO() const { return mFBO; }
@@ -99,12 +99,12 @@ IGraphicsNanoVG::Bitmap::Bitmap(NVGcontext* pContext, const char* path, double s
   SetBitmap(nvgImageID, w, h, sourceScale, 1.f);
 }
 
-IGraphicsNanoVG::Bitmap::Bitmap(IGraphicsNanoVG* pGraphics, NVGcontext* pContext, int width, int height, float scale, float drawScale)
+IGraphicsNanoVG::Bitmap::Bitmap(IGraphicsNanoVG* pGraphics, NVGcontext* pContext, int width, int height, float scale, float drawScale, bool useFloat32)
 {
   assert(width > 0 && height > 0);
   mGraphics = pGraphics;
   mVG = pContext;
-  mFBO = nvgCreateFramebuffer(pContext, width, height, 0);
+  mFBO = nvgCreateFramebuffer(pContext, width, height, (useFloat32) ? NVG_IMAGE_FLOAT32 : 0);
   
   nvgBindFramebuffer(mFBO);
   
@@ -370,14 +370,14 @@ APIBitmap* IGraphicsNanoVG::LoadAPIBitmap(const char* name, const void* pData, i
   return pBitmap;
 }
 
-APIBitmap* IGraphicsNanoVG::CreateAPIBitmap(int width, int height, float scale, double drawScale, bool cacheable)
+APIBitmap* IGraphicsNanoVG::CreateAPIBitmap(int width, int height, float scale, double drawScale, bool cacheable, bool useFloat32)
 {
   if (mInDraw)
   {
     nvgEndFrame(mVG);
   }
   
-  APIBitmap* pAPIBitmap = new Bitmap(this, mVG, width, height, scale, drawScale);
+  APIBitmap* pAPIBitmap = new Bitmap(this, mVG, width, height, scale, drawScale, useFloat32);
 
   if (mInDraw)
   {

--- a/IGraphics/Drawing/IGraphicsNanoVG.h
+++ b/IGraphics/Drawing/IGraphicsNanoVG.h
@@ -128,7 +128,7 @@ public:
 protected:
   APIBitmap* LoadAPIBitmap(const char* fileNameOrResID, int scale, EResourceLocation location, const char* ext) override;
   APIBitmap* LoadAPIBitmap(const char* name, const void* pData, int dataSize, int scale) override;
-  APIBitmap* CreateAPIBitmap(int width, int height, float scale, double drawScale, bool cacheable = false) override;
+  APIBitmap* CreateAPIBitmap(int width, int height, float scale, double drawScale, bool cacheable = false, bool useFloat32 = false) override;
 
   bool LoadAPIFont(const char* fontID, const PlatformFontPtr& font) override;
 

--- a/IGraphics/IGraphics.cpp
+++ b/IGraphics/IGraphics.cpp
@@ -1984,14 +1984,14 @@ void IGraphics::EndDragResize()
   }
 }
 
-void IGraphics::StartLayer(IControl* pControl, const IRECT& r, bool cacheable)
+void IGraphics::StartLayer(IControl* pControl, const IRECT& r, bool cacheable, bool useFloat32)
 {
   auto pixelBackingScale = GetBackingPixelScale();
   IRECT alignedBounds = r.GetPixelAligned(pixelBackingScale);
   const int w = static_cast<int>(std::ceil(pixelBackingScale * std::ceil(alignedBounds.W())));
   const int h = static_cast<int>(std::ceil(pixelBackingScale * std::ceil(alignedBounds.H())));
 
-  PushLayer(new ILayer(CreateAPIBitmap(w, h, GetScreenScale(), GetDrawScale(), cacheable), alignedBounds, pControl, pControl ? pControl->GetRECT() : IRECT()));
+  PushLayer(new ILayer(CreateAPIBitmap(w, h, GetScreenScale(), GetDrawScale(), cacheable, useFloat32), alignedBounds, pControl, pControl ? pControl->GetRECT() : IRECT()));
 }
 
 void IGraphics::ResumeLayer(ILayerPtr& layer)

--- a/IGraphics/IGraphics.h
+++ b/IGraphics/IGraphics.h
@@ -525,7 +525,7 @@ public:
    * IControl* pOwner The control that owns the layer
    * @param r The bounds of the layer within the IGraphics context
    * @param cacheable Used to make sure the underlying bitmap can be shared between plug-in instances */
-  void StartLayer(IControl* pOwner, const IRECT& r, bool cacheable = false);
+  void StartLayer(IControl* pOwner, const IRECT& r, bool cacheable = false, bool useFloat32 = false);
   
   /** If a layer already exists, continue drawing to it
    * @param layer the layer to resume */
@@ -1721,7 +1721,7 @@ protected:
    * @param drawScale \todo
    * @param cacheable Used to make sure the underlying bitmap can be shared between plug-in instances
    * @return APIBitmap* The new API Bitmap */
-  virtual APIBitmap* CreateAPIBitmap(int width, int height, float scale, double drawScale, bool cacheable = false) = 0;
+  virtual APIBitmap* CreateAPIBitmap(int width, int height, float scale, double drawScale, bool cacheable = false, bool useFloat32 = false) = 0;
 
   /** Drawing API method to load a font from a PlatformFontPtr, called internally
    * @param fontID A CString that will be used to reference the font

--- a/IGraphics/IGraphics.h
+++ b/IGraphics/IGraphics.h
@@ -1720,6 +1720,7 @@ protected:
    * @param scale The scale in relation to 1:1 pixels
    * @param drawScale \todo
    * @param cacheable Used to make sure the underlying bitmap can be shared between plug-in instances
+   * @param useFloat32 Use 32-bit floats as the pixel format for the bitmap. Default is uint8.
    * @return APIBitmap* The new API Bitmap */
   virtual APIBitmap* CreateAPIBitmap(int width, int height, float scale, double drawScale, bool cacheable = false, bool useFloat32 = false) = 0;
 


### PR DESCRIPTION
8 bit images are fine for static graphics, but when using recursive effects, an 8 bit state can easily get "stuck" -  for example, the time series `x[t] = 0.95 * x[t-1], x[0] = 255` converges to 10.

These commits add an extra argument to StartLayer to create a float32 layer that behaves much better numerically. Implemented in NanoVG with the GL2, GL3 and Metal backends.